### PR TITLE
Homepage Typewriter Animation Fix & 'Get Started' Improvements

### DIFF
--- a/islands/TypewritingComp.tsx
+++ b/islands/TypewritingComp.tsx
@@ -6,11 +6,11 @@ import { useEffect, useState } from "preact/hooks";
 
 const charts = [
   "BarChart",
-  "LineChart",
+  "MapChart",
   // "ScatterplotChart",
   "PieChart",
+  "LineChart",
   "DonutChart",
-  "MapChart",
 ];
 
 export default function TypeWriting() {

--- a/utils/twind.ts
+++ b/utils/twind.ts
@@ -128,7 +128,7 @@ export const config: Configuration = {
         width: "100%",
         backgroundColor: "#42476d",
         borderLeft: "2px solid #2EE59D",
-        animation: "animate 3s .1s steps(11) infinite",
+        animation: "animate 3s steps(9) infinite",
       },
 
       ".js-keycode": {


### PR DESCRIPTION
Changed order of charts to reduce how much the whole line of text on the homepage moves between chart names, and removed a .1s delay on the animation start that was causing a slight de-sync between the animation loop and the chart name change.